### PR TITLE
feat: improve warning pages and homepage

### DIFF
--- a/projectApp/templates/index.html
+++ b/projectApp/templates/index.html
@@ -5,22 +5,22 @@
     <link rel="icon" href="{% static 'navi_icon.ico' %}" type="image/x-icon" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
     <title>Classroom environment monitoring system</title>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
     />
     <style>
-      a {
-        text-decoration: none;
-        color: inherit;
-      }
       * {
         margin: 0;
         padding: 0;
         box-sizing: border-box;
         font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      }
+
+      a {
+        text-decoration: none;
+        color: inherit;
       }
 
       body {
@@ -37,8 +37,8 @@
 
       header {
         text-align: center;
-        padding: 30px 0;
-        margin-bottom: 30px;
+        padding: 28px 0 20px;
+        margin-bottom: 20px;
       }
 
       .logo {
@@ -53,10 +53,7 @@
         margin-right: 15px;
         color: #4bcffa;
       }
-      a {
-        text-decoration: none;
-        color: inherit;
-      }
+
       h1 {
         font-size: 2.8rem;
         margin-bottom: 10px;
@@ -67,55 +64,217 @@
       }
 
       .subtitle {
-        font-size: 1.2rem;
+        font-size: 1.15rem;
         opacity: 0.9;
-        max-width: 700px;
+        max-width: 760px;
         margin: 0 auto;
         line-height: 1.6;
       }
 
-      .dashboard {
+      .overview-panel {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: 25px;
-        margin-bottom: 40px;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 16px;
+        margin-bottom: 24px;
       }
 
-      .card {
+      .overview-card {
+        background: rgba(255, 255, 255, 0.11);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 18px;
+        padding: 18px 20px;
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.18);
+        backdrop-filter: blur(10px);
+      }
+
+      .overview-label {
+        font-size: 0.9rem;
+        opacity: 0.74;
+        margin-bottom: 8px;
+      }
+
+      .overview-value {
+        font-size: 1.75rem;
+        font-weight: 750;
+        display: flex;
+        align-items: baseline;
+        gap: 6px;
+      }
+
+      .overview-unit {
+        font-size: 0.85rem;
+        font-weight: 500;
+        opacity: 0.72;
+      }
+
+      .section-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        margin: 28px 0 16px;
+      }
+
+      .section-title {
+        font-size: 1.65rem;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .section-title i {
+        color: #4bcffa;
+      }
+
+      .section-note {
+        font-size: 0.95rem;
+        opacity: 0.75;
+      }
+
+      .module-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 20px;
+        margin-bottom: 34px;
+      }
+
+      .module-card,
+      .sensor-card,
+      .classroom-list,
+      .classroom-card {
         background: rgba(255, 255, 255, 0.1);
         backdrop-filter: blur(10px);
-        border-radius: 15px;
-        padding: 25px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
         box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        transition: transform 0.3s ease, box-shadow 0.3s ease;
-        cursor: pointer;
-        display: flex;
-        flex-direction: column;
       }
 
-      .card:hover {
-        transform: translateY(-10px);
-        box-shadow: 0 15px 35px rgba(0, 0, 0, 0.3);
-        background: rgba(255, 255, 255, 0.15);
+      .module-card {
+        min-height: 112px;
+        border-radius: 18px;
+        padding: 22px;
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+      }
+
+      .module-card:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 16px 38px rgba(0, 0, 0, 0.32);
+        background: rgba(255, 255, 255, 0.16);
+      }
+
+      .module-icon {
+        flex-shrink: 0;
+        width: 58px;
+        height: 58px;
+        border-radius: 18px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.7rem;
+      }
+
+      .module-content {
+        min-width: 0;
+      }
+
+      .module-title {
+        font-size: 1.32rem;
+        font-weight: 700;
+        line-height: 1.3;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .module-desc {
+        margin-top: 6px;
+        font-size: 0.92rem;
+        opacity: 0.75;
+        line-height: 1.35;
+      }
+
+      .module-events .module-icon {
+        background: linear-gradient(135deg, #f6d365, #fda085);
+      }
+
+      .module-data .module-icon {
+        background: linear-gradient(135deg, #e0c3fc, #b5b6fb);
+      }
+
+      .module-dashboard .module-icon {
+        background: linear-gradient(135deg, #84fab0, #8fd3f4);
+      }
+
+      .module-warning .module-icon {
+        background: linear-gradient(135deg, #ffecd2, #fcb69f);
+      }
+
+      .module-log .module-icon {
+        background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+      }
+
+      .module-summary .module-icon {
+        background: linear-gradient(135deg, #a1c4fd, #c2e9fb);
+      }
+
+      .new-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 22px;
+        height: 22px;
+        padding: 0 7px;
+        background-color: #00d5ff;
+        color: white;
+        font-size: 12px;
+        border-radius: 999px;
+        animation: pulse 1.5s infinite;
+      }
+
+      @keyframes pulse {
+        0% { transform: scale(1); }
+        50% { transform: scale(1.1); }
+        100% { transform: scale(1); }
+      }
+
+      .sensor-grid {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 20px;
+        margin-bottom: 34px;
+      }
+
+      .sensor-card {
+        border-radius: 18px;
+        padding: 24px;
+        transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+        min-height: 245px;
+      }
+
+      .sensor-card:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 16px 38px rgba(0, 0, 0, 0.32);
+        background: rgba(255, 255, 255, 0.16);
       }
 
       .card-header {
         display: flex;
         align-items: center;
-        margin-bottom: 10px;
+        margin-bottom: 14px;
       }
 
       .card-icon {
         flex-shrink: 0;
-        width: 60px;
-        height: 60px;
+        width: 56px;
+        height: 56px;
         border-radius: 50%;
         display: flex;
         align-items: center;
         justify-content: center;
-        margin-right: 15px;
-        font-size: 1.8rem;
+        margin-right: 14px;
+        font-size: 1.65rem;
       }
 
       .temp .card-icon {
@@ -134,46 +293,37 @@
         background: linear-gradient(135deg, #84fab0, #8fd3f4);
       }
 
-      .addEvent .card-icon {
-        background: linear-gradient(135deg, #f6d365, #fda085);
-      }
-      .dataList .card-icon {
-        background: linear-gradient(135deg, #e0c3fc, #b5b6fb);
-      }
-      .dataMonitor .card-icon {
-        background: linear-gradient(135deg, #ffecd2, #fcb69f);
-      }
       .card-title {
-        font-size: 1.5rem;
-        font-weight: 600;
+        font-size: 1.25rem;
+        font-weight: 700;
+        line-height: 1.3;
       }
 
       .card-value {
-        font-size: 2.8rem;
-        font-weight: 700;
+        font-size: 2.55rem;
+        font-weight: 800;
         margin: 10px 0;
         text-align: center;
       }
 
       .card-unit {
-        font-size: 1.2rem;
-        opacity: 0.8;
+        font-size: 1.05rem;
+        opacity: 0.78;
         margin-left: 5px;
       }
 
       .card-status {
-        display: flex;
+        display: inline-flex;
         align-items: center;
-        padding: 5px 15px;
+        padding: 5px 14px;
         border-radius: 20px;
-        font-size: 0.9rem;
-        font-weight: 600;
-        margin-top: 10px;
-        align-self: flex-start;
+        font-size: 0.86rem;
+        font-weight: 700;
+        margin-top: 6px;
       }
 
       .status-normal {
-        background: rgba(161, 221, 185, 0.938);
+        background: rgba(161, 221, 185, 0.94);
         color: #1e8548;
       }
 
@@ -188,52 +338,62 @@
       }
 
       .card-description {
-        margin-top: 15px;
-        font-size: 0.95rem;
-        line-height: 1.6;
-        opacity: 0.85;
+        margin-top: 14px;
+        font-size: 0.93rem;
+        line-height: 1.55;
+        opacity: 0.82;
       }
 
       .classroom-list {
-        background: rgba(255, 255, 255, 0.1);
-        backdrop-filter: blur(10px);
-        border-radius: 15px;
-        padding: 25px;
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        margin-top: 30px;
-      }
-      .section-title {
-        font-size: 1.8rem;
-        margin-bottom: 20px;
-        display: flex;
-        align-items: center;
+        border-radius: 18px;
+        padding: 24px;
+        margin-top: 28px;
       }
 
-      .section-title i {
-        margin-right: 10px;
-        color: #4bcffa;
+      .classroom-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+        margin-bottom: 20px;
+      }
+
+      .map-button {
+        background: rgba(255, 255, 255, 0.12);
+        padding: 9px 16px;
+        border-radius: 999px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        transition: all 0.25s ease;
+        white-space: nowrap;
+      }
+
+      .map-button:hover {
+        background: rgba(255, 255, 255, 0.2);
+        transform: translateY(-2px);
       }
 
       .classrooms {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 20px;
+        gap: 18px;
       }
 
       .classroom-card {
-        background: rgba(255, 255, 255, 0.08);
-        border-radius: 12px;
+        border-radius: 14px;
         padding: 20px;
-        transition: all 0.3s ease;
+        transition: all 0.25s ease;
+        cursor: pointer;
       }
 
       .classroom-card:hover {
-        background: rgba(255, 255, 255, 0.15);
+        background: rgba(255, 255, 255, 0.16);
+        transform: translateY(-3px);
       }
 
       .classroom-name {
-        font-size: 1.3rem;
+        font-size: 1.25rem;
         margin-bottom: 15px;
         display: flex;
         align-items: center;
@@ -245,27 +405,28 @@
       }
 
       .classroom-metrics {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 15px;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 14px;
       }
 
       .metric {
         display: flex;
         flex-direction: column;
         align-items: center;
-        min-width: 70px;
+        justify-content: center;
+        min-height: 58px;
       }
 
       .metric-value {
-        font-size: 1.3rem;
-        font-weight: 600;
+        font-size: 1.12rem;
+        font-weight: 700;
         margin-bottom: 5px;
       }
 
       .metric-label {
-        font-size: 0.85rem;
-        opacity: 0.7;
+        font-size: 0.82rem;
+        opacity: 0.68;
       }
 
       footer {
@@ -277,49 +438,40 @@
         opacity: 0.8;
       }
 
-      @media (max-width: 768px) {
+      @media (max-width: 1024px) {
+        .overview-panel,
+        .sensor-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .module-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      @media (max-width: 680px) {
+        body {
+          padding: 14px;
+        }
+
         h1 {
-          font-size: 2.2rem;
+          font-size: 2.05rem;
         }
 
         .subtitle {
-          font-size: 1rem;
+          font-size: 0.98rem;
         }
 
-        .dashboard {
+        .overview-panel,
+        .module-grid,
+        .sensor-grid {
           grid-template-columns: 1fr;
         }
-      }
-      .toolbar {
-        justify-content: center;
-      }
-      .has-new {
-        background-color: #fffbe6;
-        border-left: 4px solid #faad14;
-        transition: all 0.3s;
-      }
 
-      .new-badge {
-        display: inline-block;
-        background-color: #00ffea91;
-        color: white;
-        font-size: 12px;
-        padding: 2px 6px;
-        border-radius: 12px;
-        margin-left: 8px;
-        vertical-align: middle;
-        animation: pulse 1.5s infinite;
-      }
-
-      @keyframes pulse {
-        0% {
-          transform: scale(1);
-        }
-        50% {
-          transform: scale(1.1);
-        }
-        100% {
-          transform: scale(1);
+        .classroom-header,
+        .section-bar {
+          flex-direction: column;
+          align-items: flex-start;
         }
       }
     </style>
@@ -332,331 +484,281 @@
           <h1>Environmental monitoring system</h1>
         </div>
         <p class="subtitle">
-          Monitor the temperature, humidity, sound and light intensity of each
-          classroom in real time to provide the best learning environment for
-          teachers and students
+          Monitor classroom temperature, humidity, sound and light intensity in
+          real time to support a comfortable learning environment.
         </p>
       </header>
-      <div class="dashboard">
-        <a href="eventlist">
-          <div class="card addEvent toolbar">
-            <div class="card-header">
-              <div class="card-icon">
-                <i class="fa-solid fa-calendar-days"></i>
-              </div>
-              <h2 class="card-title">Events</h2>
-            </div>
-          </div>
-        </a>
-        <a href="selectdata">
-          <div class="card dataList toolbar">
-            <div class="card-header">
-              <div class="card-icon">
-                <i class="fa-solid fa-database"></i>
-              </div>
-              <h2 class="card-title">Data List</h2>
-            </div>
-          </div>
-        </a>
-        <a href="monitor">
-          <div class="card dataMonitor toolbar">
-            <div class="card-header">
-              <div class="card-icon">
-                <i class="fa-solid fa-triangle-exclamation"></i>
-              </div>
-              <h2 class="card-title">Data Warning</h2>
-            </div>
-          </div>
-        </a>
-        <a href="log">
-          <div class="card temp toolbar">
-            <div class="card-header">
-                <div class="card-icon">
-                    <i class="fa-solid fa-list"></i>
-                </div>
-                {% if check > 0 %}
-                <h2 class="card-title">Data Log <span class="new-badge">{{check}}</span></h2>
-                {% else %}
-                <h2 class="card-title">Data Log</h2>
-                {% endif %}
-            </div>
+
+      <section class="overview-panel" aria-label="Quick system overview">
+        <div class="overview-card">
+          <div class="overview-label">Classrooms</div>
+          <div class="overview-value">{{ classroom_count }}<span class="overview-unit">rooms</span></div>
         </div>
-        </a>
-        <a href="warning-summary">
-          <div class="card humidity toolbar">
-            <div class="card-header">
-              <div class="card-icon">
-                <i class="fa-solid fa-chart-pie"></i>
-              </div>
-              <h2 class="card-title">Warning Summary</h2>
-            </div>
+        <div class="overview-card">
+          <div class="overview-label">Sensor Records</div>
+          <div class="overview-value">{{ data_count }}<span class="overview-unit">rows</span></div>
+        </div>
+        <div class="overview-card">
+          <div class="overview-label">Unchecked Warnings</div>
+          <div class="overview-value">{{ check }}<span class="overview-unit">items</span></div>
+        </div>
+        <div class="overview-card">
+          <div class="overview-label">Latest Update</div>
+          <div class="overview-value">
+            {% if latest_update %}
+              {{ latest_update.date_created|date:"m-d H:i" }}
+            {% else %}
+              --
+            {% endif %}
           </div>
-        </a>
+        </div>
+      </section>
+
+      <div class="section-bar">
+        <h2 class="section-title"><i class="fas fa-layer-group"></i> Function Modules</h2>
+        <p class="section-note">Fast access to data, warning and dashboard pages</p>
       </div>
-      <a href="dashboard/classroom">
-        <div class="dashboard">
-          <div class="card temp">
-            <div class="card-header">
-              <div class="card-icon">
-                <i class="fas fa-thermometer-half"></i>
-              </div>
-              <h2 class="card-title">Temperature Monitoring</h2>
-            </div>
-            <div class="card-value">
-              {{all.temp}}<span class="card-unit">°C</span>
-            </div>
-            <span class="card-status status-normal temp-status"
-              >Normal Range</span
-            >
-            <p class="card-description">
-              Monitor the temperature conditions in each classroom to ensure a
-              comfortable learning range (20°C-26°C).
-            </p>
-          </div>
 
-          <div class="card humidity">
-            <div class="card-header">
-              <div class="card-icon">
-                <i class="fas fa-tint"></i>
-              </div>
-              <h2 class="card-title">Humidity Monitoring</h2>
-            </div>
-            <div class="card-value">
-              {{all.hum}}<span class="card-unit">%</span>
-            </div>
-            <span class="card-status status-normal hum-status"
-              >Ideal humidity</span
-            >
-            <p class="card-description">
-              Keep the humidity in the classroom between 40% and 60% to create
-              the best learning environment and prevent the air from being too
-              dry or too humid.
-            </p>
+      <nav class="module-grid" aria-label="Function modules">
+        <a href="eventlist" class="module-card module-events">
+          <div class="module-icon"><i class="fa-solid fa-calendar-days"></i></div>
+          <div class="module-content">
+            <h2 class="module-title">Events</h2>
+            <p class="module-desc">Manage classroom appointments and schedules.</p>
           </div>
+        </a>
 
-          <div class="card sound">
-            <div class="card-header">
-              <div class="card-icon">
-                <i class="fas fa-volume-up"></i>
-              </div>
-              <h2 class="card-title">Sound Monitoring</h2>
-            </div>
-            <div class="card-value">
-              {{all.snd}}<span class="card-unit">dB</span>
-            </div>
-            <span class="card-status status-warning snd-status"
-              >Slightly Higher</span
-            >
-            <p class="card-description">
-              Monitor the noise level in the classroom environment. The ideal
-              learning environment should be below 60 decibels.
-            </p>
+        <a href="selectdata" class="module-card module-data">
+          <div class="module-icon"><i class="fa-solid fa-database"></i></div>
+          <div class="module-content">
+            <h2 class="module-title">Data List</h2>
+            <p class="module-desc">Search and inspect sensor records.</p>
           </div>
+        </a>
 
-          <div class="card light">
-            <div class="card-header">
-              <div class="card-icon">
-                <i class="fas fa-lightbulb"></i>
-              </div>
-              <h2 class="card-title">Light Monitoring</h2>
-            </div>
-            <div class="card-value">
-              {{all.light}}<span class="card-unit">%</span>
-            </div>
-            <span class="card-status status-normal light-status"
-              >Normal Range</span
-            >
-            <p class="card-description">
-              Make sure the lighting in the classroom is normal.
-            </p>
+        <a href="dashboard/classroom" class="module-card module-dashboard">
+          <div class="module-icon"><i class="fa-solid fa-chart-simple"></i></div>
+          <div class="module-content">
+            <h2 class="module-title">Dashboard</h2>
+            <p class="module-desc">View classroom charts and trend analysis.</p>
           </div>
-        </div>
-      </a>
-      <div class="classroom-list">
-        <div
-          style="
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 20px;
-          "
-        >
-          <h2 class="section-title">
-            <i class="fas fa-school"></i>Classroom Environment Status
-          </h2>
-          <a
-            href="map"
-            style="
-              background: rgba(255, 255, 255, 0.1);
-              padding: 8px 15px;
-              border-radius: 20px;
-              display: flex;
-              align-items: center;
-              gap: 8px;
-              transition: all 0.3s ease;
-              color: white;
-              text-decoration: none;
-            "
-          >
-            <i class="fas fa-map"></i> MAP
-          </a>
+        </a>
+
+        <a href="monitor" class="module-card module-warning">
+          <div class="module-icon"><i class="fa-solid fa-triangle-exclamation"></i></div>
+          <div class="module-content">
+            <h2 class="module-title">Data Warning</h2>
+            <p class="module-desc">Check recent abnormal environmental readings.</p>
+          </div>
+        </a>
+
+        <a href="log" class="module-card module-log">
+          <div class="module-icon"><i class="fa-solid fa-list"></i></div>
+          <div class="module-content">
+            <h2 class="module-title">
+              Data Log
+              {% if check > 0 %}<span class="new-badge">{{ check }}</span>{% endif %}
+            </h2>
+            <p class="module-desc">Review warning logs and processing status.</p>
+          </div>
+        </a>
+
+        <a href="warning-summary" class="module-card module-summary">
+          <div class="module-icon"><i class="fa-solid fa-chart-pie"></i></div>
+          <div class="module-content">
+            <h2 class="module-title">Warning Summary</h2>
+            <p class="module-desc">Summarize warnings by status and location.</p>
+          </div>
+        </a>
+      </nav>
+
+      <div class="section-bar">
+        <h2 class="section-title"><i class="fas fa-gauge-high"></i> Environment Overview</h2>
+        <p class="section-note">Average values across current classrooms</p>
+      </div>
+
+      <section class="sensor-grid">
+        <a href="dashboard/classroom" class="sensor-card temp">
+          <div class="card-header">
+            <div class="card-icon"><i class="fas fa-thermometer-half"></i></div>
+            <h2 class="card-title">Temperature Monitoring</h2>
+          </div>
+          <div class="card-value">{{ all.temp }}<span class="card-unit">°C</span></div>
+          <span class="card-status status-normal temp-status">Normal Range</span>
+          <p class="card-description">Monitor classroom temperature and keep it within a comfortable range.</p>
+        </a>
+
+        <a href="dashboard/classroom" class="sensor-card humidity">
+          <div class="card-header">
+            <div class="card-icon"><i class="fas fa-tint"></i></div>
+            <h2 class="card-title">Humidity Monitoring</h2>
+          </div>
+          <div class="card-value">{{ all.hum }}<span class="card-unit">%</span></div>
+          <span class="card-status status-normal hum-status">Ideal Humidity</span>
+          <p class="card-description">Track humidity conditions to avoid overly dry or humid classrooms.</p>
+        </a>
+
+        <a href="dashboard/classroom" class="sensor-card sound">
+          <div class="card-header">
+            <div class="card-icon"><i class="fas fa-volume-up"></i></div>
+            <h2 class="card-title">Sound Monitoring</h2>
+          </div>
+          <div class="card-value">{{ all.snd }}<span class="card-unit">dB</span></div>
+          <span class="card-status status-warning snd-status">Slightly Higher</span>
+          <p class="card-description">Monitor noise levels and identify classrooms that may affect learning.</p>
+        </a>
+
+        <a href="dashboard/classroom" class="sensor-card light">
+          <div class="card-header">
+            <div class="card-icon"><i class="fas fa-lightbulb"></i></div>
+            <h2 class="card-title">Light Monitoring</h2>
+          </div>
+          <div class="card-value">{{ all.light }}<span class="card-unit">%</span></div>
+          <span class="card-status status-normal light-status">Normal Range</span>
+          <p class="card-description">Check whether the classroom lighting is suitable for teaching activities.</p>
+        </a>
+      </section>
+
+      <section class="classroom-list">
+        <div class="classroom-header">
+          <h2 class="section-title"><i class="fas fa-school"></i> Classroom Environment Status</h2>
+          <a href="map" class="map-button"><i class="fas fa-map"></i> MAP</a>
         </div>
 
         <div class="classrooms">
-          {% for i in locs%}
-          <div
-            class="classroom-card"
-            data-loc="{{i.env.loc}}"
-            style="margin: auto; cursor: pointer"
-          >
-            <h3 class="classroom-name">
-              <i class="fas fa-chalkboard"></i>{{i.env.loc}}
-            </h3>
+          {% for i in locs %}
+          <div class="classroom-card" data-loc="{{ i.env.loc }}">
+            <h3 class="classroom-name"><i class="fas fa-chalkboard"></i>{{ i.env.loc }}</h3>
             <div class="classroom-metrics">
-              <div class="metric" style="margin: auto">
-                <div class="metric-value">{{i.env.temp}}°C</div>
+              <div class="metric">
+                <div class="metric-value">{{ i.env.temp }}°C</div>
                 <div class="metric-label">Temp</div>
               </div>
-              <div class="metric" style="margin: auto">
-                <div class="metric-value">{{i.env.hum}}%</div>
+              <div class="metric">
+                <div class="metric-value">{{ i.env.hum }}%</div>
                 <div class="metric-label">Humidity</div>
               </div>
-              <div class="metric" style="margin: auto">
-                <div class="metric-value">{{i.env.snd}}dB</div>
+              <div class="metric">
+                <div class="metric-value">{{ i.env.snd }}dB</div>
                 <div class="metric-label">Sound</div>
               </div>
-              <div class="metric" style="margin: auto">
-                <div class="metric-value">{{i.env.light}}</div>
+              <div class="metric">
+                <div class="metric-value">{{ i.env.light }}</div>
                 <div class="metric-label">Light</div>
               </div>
               {% if i.empty == True %}
-              <div class="metric" style="margin: auto">
-                <div
-                  class="metric-value"
-                  style="color: rgb(120, 228, 120); font-size: 15px"
-                >
-                  Empty
-                </div>
+              <div class="metric">
+                <div class="metric-value" style="color: rgb(120, 228, 120); font-size: 15px">Empty</div>
                 <div class="metric-label">Status</div>
               </div>
               {% else %}
-              <div
-                class="metric clickable-row"
-                style="margin: auto; cursor: pointer"
-                data-id="{{ i.detail.id }}"
-              >
-                <div
-                  class="metric-value"
-                  style="color: rgb(231, 97, 97); font-size: 17px"
-                >
-                  {{i.detail.name}}
-                </div>
+              <div class="metric clickable-row" data-id="{{ i.detail.id }}">
+                <div class="metric-value" style="color: rgb(231, 97, 97); font-size: 17px">{{ i.detail.name }}</div>
                 <div class="metric-label">Status</div>
               </div>
               {% endif %}
-              <div class="metric" style="margin: auto">
-                <div class="metric-value" style="font-size: 14px">
-                  {{i.env.date_created | date:"m-d H:i"}}
-                </div>
+              <div class="metric">
+                <div class="metric-value" style="font-size: 14px">{{ i.env.date_created|date:"m-d H:i" }}</div>
                 <div class="metric-label">Update</div>
               </div>
             </div>
           </div>
+          {% empty %}
+          <div class="classroom-card">
+            <h3 class="classroom-name"><i class="fas fa-circle-info"></i>No classroom data</h3>
+            <p class="card-description">No sensor records are available in the current database.</p>
+          </div>
           {% endfor %}
         </div>
-      </div>
+      </section>
 
       <footer>
-        <p>
-          Classroom environment monitoring system &copy; 2025 | Real-time data
-          update | By Group A09
-        </p>
+        <p>Classroom environment monitoring system &copy; 2025 | Real-time data update | By Group A09</p>
       </footer>
     </div>
 
     <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        document.querySelectorAll('.classroom-card').forEach(card => {
-            card.addEventListener('click', () => {
+      document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll(".classroom-card[data-loc]").forEach((card) => {
+          card.addEventListener("click", () => {
             const loc = card.dataset.loc;
-          window.location.href = `dashboard/classroom?loc=${loc}`;
-        });
-      });
-          document.querySelectorAll('.clickable-row').forEach(div => {
-              div.addEventListener('click', function(event) {
-                  console.log("check");
-                  event.stopPropagation(); // 阻止冒泡
-                  const eventId = this.getAttribute('data-id');
-                  if (eventId) {
-                      window.location.href = `/eventlist?id=${eventId}`;
-                  }
-              });
+            window.location.href = `dashboard/classroom?loc=${loc}`;
           });
-      });
-            function updata_data(){
-             // Temperature
-                 document.querySelectorAll('.temp-status').forEach(status => {
-                     const all_temp = {{all.temp}};
-                     console.log({{all.temp}});
-                     if (all_temp>30) {
-                         status.className = 'card-status status-warning';
-                         status.textContent = 'Hot';
-                     } else if(all_temp< 18){
-                         status.className = 'card-status status-low';
-                         status.textContent = 'Cold';
-                     }else{
-                          status.className = 'card-status status-normal';
-                         status.textContent = 'Normal';
-                     }
-                 });
-                 //Hum
-                 document.querySelectorAll('.hum-status').forEach(status => {
-                     const all_temp = {{all.hum}};
-                     if (all_temp>80) {
-                         status.className = 'card-status status-warning';
-                         status.textContent = 'High';
-                     } else if(all_temp< 30){
-                         status.className = 'card-status status-low';
-                         status.textContent = 'Low';
-                     }else{
-                          status.className = 'card-status status-normal';
-                         status.textContent = 'Optimal';
-                     }
-                 });
-                 document.querySelectorAll('.snd-status').forEach(status => {
-                     const all_temp = {{all.snd}};
-                     if (all_temp>70) {
-                         status.className = 'card-status status-warning';
-                         status.textContent = 'Loud';
-                     } else if(all_temp< 50){
-                         status.className = 'card-status status-low';
-                         status.textContent = 'Quiet';
-                     }else{
-                          status.className = 'card-status status-normal';
-                         status.textContent = 'Moderate';
-                     }
-                 });
-                 document.querySelectorAll('.light-status').forEach(status => {
-                     const all_temp = {{all.light}};
-                     if (all_temp>90) {
-                         status.className = 'card-status status-warning';
-                         status.textContent = 'Bright';
-                     } else if(all_temp< 30){
-                         status.className = 'card-status status-low';
-                         status.textContent = 'Off';
-                     }else{
-                          status.className = 'card-status status-normal';
-                         status.textContent = 'Moderate';
-                     }
-                 });
+        });
+
+        document.querySelectorAll(".clickable-row").forEach((div) => {
+          div.addEventListener("click", function (event) {
+            event.stopPropagation();
+            const eventId = this.getAttribute("data-id");
+            if (eventId) {
+              window.location.href = `/eventlist?id=${eventId}`;
             }
-            updata_data();
-            window.onload = function(){
-                 setTimeout(function(){
-                     console.log("refresh")
-                     location.reload();
-                 },60000)
-            };
+          });
+        });
+
+        function updateStatus() {
+          document.querySelectorAll(".temp-status").forEach((status) => {
+            const value = Number("{{ all.temp }}");
+            if (value > 30) {
+              status.className = "card-status status-warning temp-status";
+              status.textContent = "Hot";
+            } else if (value < 18) {
+              status.className = "card-status status-low temp-status";
+              status.textContent = "Cold";
+            } else {
+              status.className = "card-status status-normal temp-status";
+              status.textContent = "Normal";
+            }
+          });
+
+          document.querySelectorAll(".hum-status").forEach((status) => {
+            const value = Number("{{ all.hum }}");
+            if (value > 80) {
+              status.className = "card-status status-warning hum-status";
+              status.textContent = "High";
+            } else if (value < 30) {
+              status.className = "card-status status-low hum-status";
+              status.textContent = "Low";
+            } else {
+              status.className = "card-status status-normal hum-status";
+              status.textContent = "Optimal";
+            }
+          });
+
+          document.querySelectorAll(".snd-status").forEach((status) => {
+            const value = Number("{{ all.snd }}");
+            if (value > 70) {
+              status.className = "card-status status-warning snd-status";
+              status.textContent = "Loud";
+            } else if (value < 50) {
+              status.className = "card-status status-low snd-status";
+              status.textContent = "Quiet";
+            } else {
+              status.className = "card-status status-normal snd-status";
+              status.textContent = "Moderate";
+            }
+          });
+
+          document.querySelectorAll(".light-status").forEach((status) => {
+            const value = Number("{{ all.light }}");
+            if (value > 90) {
+              status.className = "card-status status-warning light-status";
+              status.textContent = "Bright";
+            } else if (value < 30) {
+              status.className = "card-status status-low light-status";
+              status.textContent = "Off";
+            } else {
+              status.className = "card-status status-normal light-status";
+              status.textContent = "Moderate";
+            }
+          });
+        }
+
+        updateStatus();
+        setTimeout(function () {
+          location.reload();
+        }, 60000);
+      });
     </script>
   </body>
 </html>

--- a/projectApp/templates/index.html
+++ b/projectApp/templates/index.html
@@ -382,6 +382,16 @@
             </div>
         </div>
         </a>
+        <a href="warning-summary">
+          <div class="card humidity toolbar">
+            <div class="card-header">
+              <div class="card-icon">
+                <i class="fa-solid fa-chart-pie"></i>
+              </div>
+              <h2 class="card-title">Warning Summary</h2>
+            </div>
+          </div>
+        </a>
       </div>
       <a href="dashboard/classroom">
         <div class="dashboard">

--- a/projectApp/templates/projectApp/env-monitor-v3.html
+++ b/projectApp/templates/projectApp/env-monitor-v3.html
@@ -371,7 +371,13 @@
     </header>
 
     <!-- 主内容区 -->
-    <main class="main-container">   
+    <main class="main-container">
+            {% if notice_message %}
+            <div class="mb-6 px-4 py-3 rounded-lg border {% if notice_type == 'warning' %}bg-yellow-100 text-yellow-800 border-yellow-300{% else %}bg-green-100 text-green-800 border-green-300{% endif %}">
+                <strong>Data Notice:</strong> {{ notice_message }}
+            </div>
+            {% endif %}
+
             <!-- 阈值设置卡片 -->
             <div class="bg-white rounded-xl p-6 mb-8 card-shadow">
                 <h2 class="text-xl font-semibold mb-4 flex items-center">
@@ -440,7 +446,7 @@
             <div class="bg-white rounded-xl p-6 card-shadow w-full">
                 <div class="flex items-center justify-between mb-4">
                     <h2 class="text-xl font-semibold flex items-center">
-                        <i class="fa fa-table text-primary mr-2"></i>  Recent 24h Data Records
+                        <i class="fa fa-table text-primary mr-2"></i>  {{ table_title }}
                     </h2>
                     <span id="totalRecords" class="text-sm bg-gray-100 px-3 py-1 rounded-full">0 Records</span>
                 </div>

--- a/projectApp/templates/projectApp/warning_summary.html
+++ b/projectApp/templates/projectApp/warning_summary.html
@@ -1,0 +1,158 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="{% static 'warning.ico' %}" type="image/x-icon">
+    <title>Warning Summary</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-900 min-h-screen text-slate-100">
+    <a href="/" class="fixed top-6 left-6 w-12 h-12 rounded-full bg-white/20 hover:bg-white/30 flex items-center justify-center text-white shadow-lg transition-all" title="Home">
+        <i class="fas fa-home text-xl"></i>
+    </a>
+
+    <header class="bg-gradient-to-r from-blue-700 to-indigo-800 py-10 shadow-xl">
+        <div class="max-w-7xl mx-auto px-6">
+            <h1 class="text-4xl font-bold flex items-center gap-3">
+                <i class="fa-solid fa-chart-pie"></i>
+                Warning Summary
+            </h1>
+            <p class="text-blue-100 mt-2">Overview of warning logs and recent abnormal classroom environment messages.</p>
+        </div>
+    </header>
+
+    <main class="max-w-7xl mx-auto px-6 py-8">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+            <div class="bg-white text-slate-800 rounded-2xl p-6 shadow-lg">
+                <div class="text-sm font-semibold text-slate-500 uppercase tracking-wide">Total Warnings</div>
+                <div class="text-4xl font-bold mt-3">{{ total_warnings }}</div>
+            </div>
+            <div class="bg-white text-slate-800 rounded-2xl p-6 shadow-lg">
+                <div class="text-sm font-semibold text-slate-500 uppercase tracking-wide">Unchecked Warnings</div>
+                <div class="text-4xl font-bold mt-3 text-red-600">{{ unchecked_warnings }}</div>
+            </div>
+            <div class="bg-white text-slate-800 rounded-2xl p-6 shadow-lg">
+                <div class="text-sm font-semibold text-slate-500 uppercase tracking-wide">Checked Warnings</div>
+                <div class="text-4xl font-bold mt-3 text-green-600">{{ checked_warnings }}</div>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <section class="bg-white text-slate-800 rounded-2xl p-6 shadow-lg">
+                <div class="flex items-center justify-between mb-4">
+                    <h2 class="text-xl font-semibold flex items-center gap-2">
+                        <i class="fa-solid fa-location-dot text-blue-600"></i>
+                        Warning Count by Location
+                    </h2>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200">
+                        <thead class="bg-slate-50">
+                            <tr>
+                                <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Location</th>
+                                <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Warning Count</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-200">
+                            {% for item in warning_by_location %}
+                            <tr>
+                                <td class="px-4 py-3 font-medium">{{ item.loc }}</td>
+                                <td class="px-4 py-3">{{ item.warning_count }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr>
+                                <td colspan="2" class="px-4 py-6 text-center text-slate-500">No warning records found.</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="bg-white text-slate-800 rounded-2xl p-6 shadow-lg">
+                <div class="flex items-center justify-between mb-4">
+                    <h2 class="text-xl font-semibold flex items-center gap-2">
+                        <i class="fa-solid fa-clock-rotate-left text-orange-500"></i>
+                        Recent Warnings
+                    </h2>
+                    <a href="/log" class="text-sm text-blue-600 hover:underline">Open Data Log</a>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200">
+                        <thead class="bg-slate-50">
+                            <tr>
+                                <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Time</th>
+                                <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Location</th>
+                                <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Status</th>
+                                <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Messages</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-200">
+                            {% for warning in recent_warnings %}
+                            <tr>
+                                <td class="px-4 py-3 whitespace-nowrap">{{ warning.date_created|date:"Y-m-d H:i" }}</td>
+                                <td class="px-4 py-3 font-medium">{{ warning.loc }}</td>
+                                <td class="px-4 py-3">
+                                    {% if warning.status %}
+                                    <span class="px-2 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-700">Checked</span>
+                                    {% else %}
+                                    <span class="px-2 py-1 rounded-full text-xs font-semibold bg-red-100 text-red-700">Unchecked</span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-4 py-3">{{ warning.message.count }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr>
+                                <td colspan="4" class="px-4 py-6 text-center text-slate-500">No warning records found.</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        </div>
+
+        <section class="bg-white text-slate-800 rounded-2xl p-6 shadow-lg mt-8">
+            <h2 class="text-xl font-semibold flex items-center gap-2 mb-4">
+                <i class="fa-solid fa-message text-indigo-600"></i>
+                Recent Warning Messages
+            </h2>
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-200">
+                    <thead class="bg-slate-50">
+                        <tr>
+                            <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Time</th>
+                            <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Location</th>
+                            <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Temperature</th>
+                            <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Humidity</th>
+                            <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Light</th>
+                            <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Sound</th>
+                            <th class="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Message</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-slate-200">
+                        {% for message in recent_messages %}
+                        <tr>
+                            <td class="px-4 py-3 whitespace-nowrap">{{ message.information.date_created|date:"Y-m-d H:i" }}</td>
+                            <td class="px-4 py-3 font-medium">{{ message.information.loc }}</td>
+                            <td class="px-4 py-3">{{ message.information.temp }} °C</td>
+                            <td class="px-4 py-3">{{ message.information.hum }} %</td>
+                            <td class="px-4 py-3">{{ message.information.light }} %</td>
+                            <td class="px-4 py-3">{{ message.information.snd }} dB</td>
+                            <td class="px-4 py-3">{{ message.message|default:"-" }}</td>
+                        </tr>
+                        {% empty %}
+                        <tr>
+                            <td colspan="7" class="px-4 py-6 text-center text-slate-500">No warning messages found.</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/projectApp/urls.py
+++ b/projectApp/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     path('api/events/', EventApiView.as_view(), name='event_api'),
     path('map/', views.show_map, name='map-view'),
     path('map/image/', views.get_map_image, name='map-image'),
-    path("log",views.log_list)
+    path("log", views.log_list),
+    path("warning-summary", views.warning_summary, name="warning_summary"),
 ]

--- a/projectApp/views.py
+++ b/projectApp/views.py
@@ -351,24 +351,30 @@ def check_empty(loc,time):
     return event
 
 def navigation_page(request):
-    warning = Warning.objects.filter(status = False)
-    warning_tag = len(warning)
-    all_result = get_series_data()
+    """Render the home page with navigation cards and a quick system overview."""
+    unchecked_warning_count = Warning.objects.filter(status=False).count()
+    data_count = Information.objects.count()
+    latest_update = Information.objects.order_by("-date_created").first()
+
     location = Information.objects.values_list("loc").distinct().order_by("loc")
     locations = []
     for i in location:
+        loc_name = i[0]
         time = timezone.now()
-        event = check_empty(i[0],time)
-        empty = False
-        if len(event) == 0:
-            empty = True
+        event = check_empty(loc_name, time)
+        latest_env = Information.objects.filter(loc=loc_name).order_by("-date_created").first()
+
+        if latest_env is None:
+            continue
+
         context = {
-            "env" : Information.objects.filter(loc = i[0]).order_by("-date_created")[0],
-            "empty": empty,
+            "env": latest_env,
+            "empty": not event.exists(),
         }
-        if not empty:
+        if event.exists():
             context["detail"] = event[0]
         locations.append(context)
+
     tot_temp = 0
     tot_hum = 0
     tot_snd = 0
@@ -378,22 +384,30 @@ def navigation_page(request):
         tot_snd += i["env"].snd
         tot_hum += i["env"].hum
         tot_temp += i["env"].temp
-    tot_light /= len(locations)
-    tot_snd /= len(locations)
-    tot_hum /= len(locations)
-    tot_temp /= len(locations)
-    tot_light = "{:.2f}".format(tot_light)
-    tot_snd = "{:.2f}".format(tot_snd)
-    tot_temp = "{:.2f}".format(tot_temp)
-    tot_hum = "{:.2f}".format(tot_hum)
+
+    if locations:
+        tot_light = "{:.2f}".format(tot_light / len(locations))
+        tot_snd = "{:.2f}".format(tot_snd / len(locations))
+        tot_temp = "{:.2f}".format(tot_temp / len(locations))
+        tot_hum = "{:.2f}".format(tot_hum / len(locations))
+    else:
+        tot_light = tot_snd = tot_temp = tot_hum = "0.00"
+
     all_result = {
-        "temp" : tot_temp,
-        "hum":tot_hum,
-        "light":tot_light,
-        "snd" : tot_snd,
+        "temp": tot_temp,
+        "hum": tot_hum,
+        "light": tot_light,
+        "snd": tot_snd,
     }
-    context = {"all":all_result,"locs":locations,"check":warning_tag}
-    return render(request,"index.html",context)
+    context = {
+        "all": all_result,
+        "locs": locations,
+        "check": unchecked_warning_count,
+        "classroom_count": len(locations),
+        "data_count": data_count,
+        "latest_update": latest_update,
+    }
+    return render(request, "index.html", context)
 
 def environmental_monitoring_v3(request):
     """

--- a/projectApp/views.py
+++ b/projectApp/views.py
@@ -396,11 +396,72 @@ def navigation_page(request):
     return render(request,"index.html",context)
 
 def environmental_monitoring_v3(request):
+    """
+    Display environmental data for alert checking.
+
+    The original page only queried records from the latest 24 hours.
+    When the bundled sample database becomes old, the page will show 0 records.
+    To make the demo usable, this view falls back to the latest historical
+    records and tells the user what data range is being displayed.
+    """
     one_day_ago = timezone.now() - timedelta(days=1)
-    data = Information.objects.filter(date_created__gte = one_day_ago).order_by('-date_created')
+    recent_data = Information.objects.filter(
+        date_created__gte=one_day_ago
+    ).order_by('-date_created')
+
+    is_fallback = False
+    table_title = "Recent 24h Data Records"
+    notice_type = "success"
+    notice_message = "Showing environmental data records from the recent 24 hours."
+
+    if recent_data.exists():
+        data = recent_data
+    else:
+        data = Information.objects.all().order_by('-date_created')[:200]
+        is_fallback = True
+        table_title = "Latest Historical Data Records"
+        notice_type = "warning"
+        notice_message = (
+            "No records were found in the recent 24 hours. "
+            "The page is showing the latest 200 historical records instead."
+        )
+
     return render(request, 'projectApp/env-monitor-v3.html', {
-        'data': data
+        'data': data,
+        'is_fallback': is_fallback,
+        'table_title': table_title,
+        'notice_type': notice_type,
+        'notice_message': notice_message,
     })
+
+
+def warning_summary(request):
+    """Show summary statistics for warning logs."""
+    total_warnings = Warning.objects.count()
+    unchecked_warnings = Warning.objects.filter(status=False).count()
+    checked_warnings = Warning.objects.filter(status=True).count()
+
+    warning_by_location = Warning.objects.values('loc').annotate(
+        warning_count=Count('id')
+    ).order_by('-warning_count', 'loc')
+
+    recent_warnings = Warning.objects.prefetch_related(
+        'message', 'message__information'
+    ).order_by('-date_created')[:10]
+
+    recent_messages = WarningMessage.objects.select_related(
+        'information'
+    ).order_by('-id')[:10]
+
+    context = {
+        'total_warnings': total_warnings,
+        'unchecked_warnings': unchecked_warnings,
+        'checked_warnings': checked_warnings,
+        'warning_by_location': warning_by_location,
+        'recent_warnings': recent_warnings,
+        'recent_messages': recent_messages,
+    }
+    return render(request, 'projectApp/warning_summary.html', context)
 
 class EventApiView(View):
     def get(self, request):


### PR DESCRIPTION
## Summary

This PR improves the warning-related pages and homepage usability.

## Changes

- Add fallback data for the monitor page.
- Show the latest 200 historical records when no recent 24-hour data exists.
- Add a notice to explain whether recent data or fallback data is being displayed.
- Add a new Warning Summary page.
- Show total warnings, unchecked warnings, checked warnings, warning count by location, recent warnings, and recent warning messages.
- Improve the homepage module layout.
- Add a Quick System Overview section with classroom count, sensor record count, unchecked warning count, and latest update time.

## Testing

Tested locally with:

- `/`
- `/monitor`
- `/warning-summary`
- `/dashboard/classroom`

Closes #5